### PR TITLE
feat/auth 회원가입/로그인/JWT 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
+	// JWT (jjwt 0.12.x)
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hn/ticketing/auth/api/AuthController.java
+++ b/src/main/java/com/hn/ticketing/auth/api/AuthController.java
@@ -1,0 +1,44 @@
+package com.hn.ticketing.auth.api;
+
+import com.hn.ticketing.auth.api.dto.LoginRequest;
+import com.hn.ticketing.auth.api.dto.LoginResponse;
+import com.hn.ticketing.auth.api.dto.SignupRequest;
+import com.hn.ticketing.auth.domain.AuthService;
+import com.hn.ticketing.shared.dto.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+    /**
+     * 회원가입 API.
+     * @Valid로 SignupRequest의 Bean Validation 동작.
+     * 검증 실패 시 MethodArgumentNotValidException → GlobalExceptionHandler가 400으로 응답.
+     */
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<Long>> signup(@Valid @RequestBody SignupRequest request) {
+        Long memberId = authService.signup(request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success("회원가입 성공", memberId));
+    }
+
+    /**
+     * 로그인 API. 성공 시 JWT 반환.
+     */
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
+        LoginResponse response = authService.login(request);
+        return ResponseEntity.ok(ApiResponse.success("로그인 성공", response));
+    }
+}

--- a/src/main/java/com/hn/ticketing/auth/api/dto/LoginRequest.java
+++ b/src/main/java/com/hn/ticketing/auth/api/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.hn.ticketing.auth.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank String loginId,
+        @NotBlank String password
+) {
+}

--- a/src/main/java/com/hn/ticketing/auth/api/dto/LoginResponse.java
+++ b/src/main/java/com/hn/ticketing/auth/api/dto/LoginResponse.java
@@ -1,0 +1,11 @@
+package com.hn.ticketing.auth.api.dto;
+
+public record LoginResponse(
+        String accessToken,
+        String tokenType,   // "Bearer"
+        long expiresIn      // 초 단위 TTL
+) {
+    public static LoginResponse of(String token, long expiresInSeconds) {
+        return new LoginResponse(token, "Bearer", expiresInSeconds);
+    }
+}

--- a/src/main/java/com/hn/ticketing/auth/api/dto/SignupRequest.java
+++ b/src/main/java/com/hn/ticketing/auth/api/dto/SignupRequest.java
@@ -1,0 +1,24 @@
+package com.hn.ticketing.auth.api.dto;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 회원가입 요청 DTO.
+ * Bean Validation 어노테이션은 @Valid가 붙은 컨트롤러 파라미터에서 자동 검증되어
+ * GlobalExceptionHandler의 handleValidationException으로 전달된다.
+ */
+public record SignupRequest(
+        @NotBlank(message = "아이디는 필수입니다")
+        @Pattern(regexp = "^[a-zA-Z0-9_]{4,20}$", message = "아이디는 4~20자 영문/숫자/언더바만 가능")
+        String loginId,
+
+        @NotBlank(message = "비밀번호는 필수입니다")
+        @Size(min = 8, max = 30, message = "비밀번호는 8~30자")
+        String password,
+
+        @NotBlank(message = "닉네임은 필수입니다")
+        @Size(min = 2, max = 15, message = "닉네임은 2~15자")
+        String nickname
+) {
+}

--- a/src/main/java/com/hn/ticketing/auth/domain/AuthService.java
+++ b/src/main/java/com/hn/ticketing/auth/domain/AuthService.java
@@ -1,0 +1,69 @@
+package com.hn.ticketing.auth.domain;
+
+import com.hn.ticketing.auth.api.dto.LoginRequest;
+import com.hn.ticketing.auth.api.dto.LoginResponse;
+import com.hn.ticketing.auth.api.dto.SignupRequest;
+import com.hn.ticketing.auth.domain.exception.DuplicateLoginIdException;
+import com.hn.ticketing.auth.domain.exception.InvalidPasswordException;
+import com.hn.ticketing.auth.domain.exception.MemberNotFoundException;
+import com.hn.ticketing.auth.infrastructure.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 회원가입, 로그인 비즈니스 로직.
+ *
+ * 도메인 계층에 두는 이유:
+ *   - AuthService는 MemberRepository 인터페이스에만 의존 (JPA 몰라도 됨)
+ *   - PasswordEncoder, JwtTokenProvider는 인프라지만 Spring 표준 / 내부 컴포넌트이므로 허용
+ *
+ * 향후 인증 모듈을 서비스로 분리할 때 이 파일은 거의 수정 없이 옮길 수 있다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 회원가입.
+     *
+     * existsByLoginId 체크 후 save까지 사이에 race condition이 존재할 수 있다.
+     * 그래서 DB의 unique 제약(uk_member_login_id)이 최종 방어선이다.
+     * 동시 가입 시 DataIntegrityViolationException이 발생하는데,
+     * 이건 GlobalExceptionHandler에서 별도 처리하거나 여기서 try-catch로 래핑할 수 있다.
+     *
+     * 현재는 학습용이므로 단순 체크만 하고, race는 드문 케이스라 감내한다.
+     */
+    @Transactional
+    public Long signup(SignupRequest request) {
+        if(memberRepository.existsByLoginId(request.loginId())) {
+            throw new DuplicateLoginIdException();
+        }
+
+        // 비밀번호는 엔티티에 저장되기 전에 반드시 해싱
+        String encoded = passwordEncoder.encode(request.password());
+        Member member = Member.create(request.loginId(), encoded, request.nickname());
+        Member saved = memberRepository.save(member);
+        return saved.getId();
+    }
+    /**
+     * 로그인 → JWT 발급.
+     * 트랜잭션은 readOnly로 충분 (로그인 시 DB 쓰기 없음).
+     */
+    public LoginResponse login(LoginRequest request) {
+        Member member = memberRepository.findByLoginId(request.loginId())
+                .orElseThrow(MemberNotFoundException::new);
+
+        if(!passwordEncoder.matches(request.password(), member.getPassword())) {
+            throw new InvalidPasswordException();
+        }
+        String token = jwtTokenProvider.createAccessToken(member.getId(), member.getRole());
+        return LoginResponse.of(token, jwtTokenProvider.getValidityInSeconds());
+    }
+
+}

--- a/src/main/java/com/hn/ticketing/auth/domain/Member.java
+++ b/src/main/java/com/hn/ticketing/auth/domain/Member.java
@@ -1,0 +1,63 @@
+package com.hn.ticketing.auth.domain;
+
+import com.hn.ticketing.shared.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 회원 엔티티.
+ * 기획안에서 인증은 "동작하는 수준"까지만 구현(Out-of-Scope: refresh token, 소셜 로그인 등).
+ * 따라서 필드는 최소한만 둔다.
+ */
+@Entity
+@Table(
+        name = "member",
+        uniqueConstraints = {
+                // loginId 중복 체크는 서비스 계층에서 먼저 하지만,
+                // 동시 가입 요청에서의 race condition을 막기 위해 DB 유니크 제약이 최종 방어선이다.
+                @UniqueConstraint(name = "uk_member_login_id", columnNames = "login_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)  // JPA는 기본 생성자 필요, 외부에서는 Builder만 쓰도록 제한
+public class Member extends BaseEntity {
+
+    @Column(name = "login_id", nullable = false, length = 50)
+    private String loginId;
+
+    // BCrypt 해시 값. 60자 고정.
+    @Column(name = "password", nullable = false, length = 60)
+    private String password;
+
+    @Column(name = "nickname", nullable = false, length = 30)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)  // ORDINAL은 enum 순서 변경 시 재앙이므로 반드시 STRING
+    @Column(name = "role", nullable = false, length = 20)
+    private Role role;
+
+    @Builder
+    private Member(String loginId, String password, String nickname, Role role) {
+        this.loginId = loginId;
+        this.password = password;
+        this.nickname = nickname;
+        this.role = role;
+    }
+
+    /**
+     * 회원가입 시 사용하는 팩토리 메서드.
+     * 비밀번호 해싱은 서비스 계층에서 이미 완료된 상태로 전달받는다.
+     * (엔티티가 PasswordEncoder에 의존하면 도메인이 인프라에 오염됨)
+     */
+    public static Member create(String loginId, String encodedPassword, String nickname) {
+        return Member.builder()
+                .loginId(loginId)
+                .password(encodedPassword)
+                .nickname(nickname)
+                .role(Role.USER)
+                .build();
+    }
+}

--- a/src/main/java/com/hn/ticketing/auth/domain/MemberRepository.java
+++ b/src/main/java/com/hn/ticketing/auth/domain/MemberRepository.java
@@ -1,0 +1,20 @@
+package com.hn.ticketing.auth.domain;
+
+import java.util.Optional;
+
+/**
+ * 도메인 계층의 Repository 인터페이스.
+ * JPA에 직접 의존하지 않도록 인터페이스로 정의하고,
+ * 구현체는 infrastructure 계층의 JpaMemberRepository가 담당.
+ *
+ * 이렇게 분리하면 테스트에서 Fake 구현체로 쉽게 교체 가능하고,
+ * 향후 저장소가 바뀌어도 도메인 코드는 영향받지 않는다.
+ */
+public interface MemberRepository {
+
+    Member save(Member member);
+
+    Optional<Member> findByLoginId(String loginId);
+
+    boolean existsByLoginId(String loginId);
+}

--- a/src/main/java/com/hn/ticketing/auth/domain/Role.java
+++ b/src/main/java/com/hn/ticketing/auth/domain/Role.java
@@ -1,0 +1,18 @@
+package com.hn.ticketing.auth.domain;
+
+// 사용자 권한 enum
+// 확장 계획은 없지만, Spring Security의 hasRole과 매핑되도록 ROLE_ 접두사를 붙임
+public enum Role {
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String key;
+
+    Role(String key) {
+        this.key = key;
+    }
+
+    public String getKey() {
+        return key;
+    }
+}

--- a/src/main/java/com/hn/ticketing/auth/domain/exception/DuplicateLoginIdException.java
+++ b/src/main/java/com/hn/ticketing/auth/domain/exception/DuplicateLoginIdException.java
@@ -1,0 +1,10 @@
+package com.hn.ticketing.auth.domain.exception;
+
+import com.hn.ticketing.shared.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicateLoginIdException extends BaseException {
+    public DuplicateLoginIdException() {
+        super(HttpStatus.CONFLICT, "DUPLICATE_LOGIN_ID", "이미 존재하는 아이디입니다");
+    }
+}

--- a/src/main/java/com/hn/ticketing/auth/domain/exception/InvalidPasswordException.java
+++ b/src/main/java/com/hn/ticketing/auth/domain/exception/InvalidPasswordException.java
@@ -1,0 +1,10 @@
+package com.hn.ticketing.auth.domain.exception;
+
+import com.hn.ticketing.shared.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidPasswordException extends BaseException {
+    public InvalidPasswordException() {
+        super(HttpStatus.UNAUTHORIZED, "INVALID_PASSWORD", "비밀번호가 일치하지 않습니다");
+    }
+}

--- a/src/main/java/com/hn/ticketing/auth/domain/exception/MemberNotFoundException.java
+++ b/src/main/java/com/hn/ticketing/auth/domain/exception/MemberNotFoundException.java
@@ -1,0 +1,10 @@
+package com.hn.ticketing.auth.domain.exception;
+
+import com.hn.ticketing.shared.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class MemberNotFoundException extends BaseException {
+    public MemberNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "회원을 찾을 수 없습니다");
+    }
+}

--- a/src/main/java/com/hn/ticketing/auth/infrastructure/JpaMemberRepository.java
+++ b/src/main/java/com/hn/ticketing/auth/infrastructure/JpaMemberRepository.java
@@ -1,0 +1,28 @@
+package com.hn.ticketing.auth.infrastructure;
+
+import com.hn.ticketing.auth.domain.Member;
+import com.hn.ticketing.auth.domain.MemberRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * Spring Data JPA를 사용한 MemberRepository 구현체.
+ *
+ * 한 인터페이스가 도메인의 MemberRepository와 Spring Data의 JpaRepository를 동시에 상속.
+ * → Spring이 자동으로 구현체 빈을 생성해주고, 도메인은 MemberRepository 타입으로만 주입받음.
+ *
+ * 패키지는 infrastructure인데 타입은 domain.MemberRepository를 상속하는 이유:
+ * → 의존성 방향을 domain ← infrastructure로 유지하기 위함 (DIP)
+ */
+public interface JpaMemberRepository extends MemberRepository, JpaRepository<Member, Long> {
+
+    // findByLoginId, existsByLoginId는 Spring Data JPA가 메서드 이름 규약으로 자동 구현.
+    // MemberRepository 인터페이스에 선언만 해두면 여기서 추가 선언 불필요.
+
+    @Override
+    Optional<Member> findByLoginId(String loginId);
+
+    @Override
+    boolean existsByLoginId(String loginId);
+}

--- a/src/main/java/com/hn/ticketing/auth/infrastructure/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hn/ticketing/auth/infrastructure/JwtAuthenticationFilter.java
@@ -1,0 +1,79 @@
+package com.hn.ticketing.auth.infrastructure;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * 매 요청마다 한 번씩 실행되는 JWT 인증 필터.
+ * OncePerRequestFilter를 상속해서 forward/include 시에도 중복 실행되지 않도록 보장.
+ *
+ * 흐름:
+ *   1. Authorization 헤더에서 Bearer 토큰 추출
+ *   2. 토큰 유효하면 SecurityContext에 Authentication 주입
+ *   3. 유효하지 않으면 그냥 통과 (이후 SecurityConfig의 authorizeHttpRequests에서 401 반환)
+ *
+ * 여기서 직접 401을 던지지 않는 이유:
+ *   - permitAll 경로(/health, /api/auth/**)는 토큰이 없어도 통과해야 함
+ *   - 인증/인가 결정은 Spring Security가 일관되게 하도록 위임
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validate(token)) {
+            Claims claims = jwtTokenProvider.parseClaims(token);
+            Long memberId = Long.valueOf(claims.getSubject());
+            String role = claims.get("role", String.class);
+
+            // principal에 memberId를 직접 넣는다.
+            // 컨트롤러에서 @AuthenticationPrincipal Long memberId로 꺼낼 수 있음.
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            memberId,
+                            null,  // credentials는 토큰 검증 후 불필요
+                            List.of(new SimpleGrantedAuthority("ROLE_" + role))
+                    );
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * "Bearer xxx.yyy.zzz" 형태에서 토큰 부분만 추출.
+     */
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearer) && bearer.startsWith(BEARER_PREFIX)) {
+            return bearer.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/hn/ticketing/auth/infrastructure/JwtTokenProvider.java
+++ b/src/main/java/com/hn/ticketing/auth/infrastructure/JwtTokenProvider.java
@@ -1,0 +1,96 @@
+package com.hn.ticketing.auth.infrastructure;
+
+import com.hn.ticketing.auth.domain.Role;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+/**
+ * JWT 토큰 생성 및 검증 담당.
+ *
+ * 이 프로젝트는 Stateless 인증이므로 토큰 자체가 세션이다.
+ * Refresh token은 비목표(§3.2).
+ */
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private final String secret;
+    private final long validityInMilliseconds;
+    private SecretKey key;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expiration-seconds}") long validityInSeconds
+    ) {
+        this.secret = secret;
+        this.validityInMilliseconds = validityInSeconds * 1000;
+    }
+
+    /**
+     * 빈 초기화 시점에 SecretKey를 한 번만 생성.
+     * 매 요청마다 만들면 낭비이고, 상수로 두면 테스트에서 교체 불가.
+     */
+    @PostConstruct
+    protected void init() {
+        byte[] keyBytes = secret.getBytes(StandardCharsets.UTF_8);
+        // HS256 기준 최소 256bit(32byte) 필요. application.yml에서 충분히 긴 시크릿을 넣어야 함.
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    /**
+     * 액세스 토큰 발급.
+     * subject에 memberId를 넣어 인증 필터에서 사용자 식별에 쓴다.
+     * claim에 role을 넣어 권한 체크를 토큰만으로 가능하게 한다.
+     */
+    public String createAccessToken(Long memberId, Role role) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .claim("role", role.name())
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    /**
+     * 토큰에서 Claims 추출. 검증도 내부적으로 같이 수행됨.
+     * 만료/서명 오류 시 JwtException 계열이 던져짐.
+     */
+    public Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    /**
+     * 필터에서 토큰 유효성만 빠르게 체크할 때 사용.
+     * 예외를 던지지 않고 boolean 반환하는 편이 필터 코드가 깔끔해진다.
+     */
+    public boolean validate(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (Exception e) {
+            log.debug("JWT 검증 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public long getValidityInSeconds() {
+        return validityInMilliseconds / 1000;
+    }
+}

--- a/src/main/java/com/hn/ticketing/shared/config/SecurityConfig.java
+++ b/src/main/java/com/hn/ticketing/shared/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.hn.ticketing.shared.config;
 
+import com.hn.ticketing.auth.infrastructure.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,7 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
     //  JWT 기반 Stateless 인증
-    //private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
@@ -29,7 +30,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**").permitAll()
                         .anyRequest().authenticated()
                 )
-                //.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 

--- a/src/main/java/com/hn/ticketing/shared/dto/ApiResponse.java
+++ b/src/main/java/com/hn/ticketing/shared/dto/ApiResponse.java
@@ -1,24 +1,20 @@
 package com.hn.ticketing.shared.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import org.springframework.http.HttpStatus;
-
-@JsonInclude(JsonInclude.Include.NON_NULL)
-public record ApiResponse<T>(int status, String message, T data) {
+public record ApiResponse<T>(
+        int status,
+        String errorCode,   // 실패 시만 채워짐, 성공 시 null
+        String message,
+        T data
+) {
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(200, null, message, data);
+    }
 
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(HttpStatus.OK.value(), "OK", data);
+        return new ApiResponse<>(200, null, "OK", data);
     }
 
-    public static <T> ApiResponse<T> success(String message, T data) {
-        return new ApiResponse<>(HttpStatus.OK.value(), message, data);
-    }
-
-    public static <T> ApiResponse<T> error(int status, String message) {
-        return new ApiResponse<>(status, message, null);
-    }
-
-    public static <T> ApiResponse<T> error(int status, String message, T data) {
-        return new ApiResponse<>(status, message, data);
+    public static ApiResponse<Void> error(int status, String errorCode, String message) {
+        return new ApiResponse<>(status, errorCode, message, null);
     }
 }

--- a/src/main/java/com/hn/ticketing/shared/exception/BaseException.java
+++ b/src/main/java/com/hn/ticketing/shared/exception/BaseException.java
@@ -3,13 +3,25 @@ package com.hn.ticketing.shared.exception;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+
+/**
+ * 모든 커스텀 예외의 부모 클래스.
+ *
+ * 필드:
+ *   - status: HTTP 응답 코드 (Spring의 HttpStatus 사용 → 매직 넘버 방지)
+ *   - errorCode: 클라이언트가 프로그래밍적으로 식별할 수 있는 코드 ("DUPLICATE_LOGIN_ID" 등)
+ *                같은 status여도 에러 원인을 구분할 수 있게 함.
+ *   - message: 사람이 읽는 메시지 (super(message)로 RuntimeException에 전달)
+ */
 @Getter
 public abstract class BaseException extends RuntimeException {
 
     private final HttpStatus status;
+    private final String errorCode;
 
-    protected BaseException(HttpStatus status, String message) {
+    protected BaseException(HttpStatus status, String errorCode, String message) {
         super(message);
         this.status = status;
+        this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/hn/ticketing/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hn/ticketing/shared/exception/GlobalExceptionHandler.java
@@ -2,53 +2,52 @@ package com.hn.ticketing.shared.exception;
 
 import com.hn.ticketing.shared.dto.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.FieldError;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.nio.file.AccessDeniedException;
-import java.util.stream.Collectors;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
 @Slf4j
-@RestControllerAdvice //API 전체에서 발생하는 예외를 감시
+@RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    // 어떤 에러를 잡을지 명시/ 컨트롤러에서 @Valid로 검증한 값이 실패했을 때 던지는 예외로 이메일 형식이 틀렸거나, 필수 값이 빠졌을 때 발생
-    public ApiResponse<Void> handleValidationException(MethodArgumentNotValidException e) {
-        String message = e.getBindingResult().getFieldErrors().stream()
-                .map(FieldError::getDefaultMessage)
-                .collect(Collectors.joining(", "));
-        return ApiResponse.error(400, message);
-    }
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ApiResponse<Void> handleIllegalArgument(IllegalArgumentException e) {
-        return ApiResponse.error(403, e.getMessage());
-    }
-
-    @ResponseStatus(HttpStatus.FORBIDDEN)
-    @ExceptionHandler(AccessDeniedException.class)
-    public ApiResponse<Void> handleAccessDenied(AccessDeniedException e) {
-        return ApiResponse.error(403, "접근 권한이 없습니다.");
-    }
-
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    @ExceptionHandler(Exception.class)
-    public ApiResponse<Void> handleGeneralException(Exception e) {
-        log.error("[GlobalExceptionHandler] Unexpected error", e);
-        return ApiResponse.error(500, "서버 내부 오류가 발생했습니다.");
-    }
-
+    /**
+     * 모든 커스텀 예외를 한 곳에서 처리.
+     * BaseException을 상속한 어떤 모듈의 예외든 여기로 들어옴.
+     */
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<ApiResponse<Void>> handleBaseException(BaseException e) {
+        log.warn("[{}] {}", e.getErrorCode(), e.getMessage());
         return ResponseEntity
                 .status(e.getStatus())
-                .body(ApiResponse.error(e.getStatus().value(), e.getMessage()));
+                .body(ApiResponse.error(e.getStatus().value(), e.getErrorCode(), e.getMessage()));
+    }
+
+    /**
+     * @Valid 검증 실패 시 자동으로 던져지는 예외.
+     * 첫 번째 필드 에러 메시지를 반환.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .orElse("입력값이 올바르지 않습니다");
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.error(400, "VALIDATION_FAILED", message));
+    }
+
+    /**
+     * 예상치 못한 모든 예외의 최종 방어선.
+     * 스택트레이스는 로그에만 남기고, 클라이언트엔 일반 메시지만 반환 (정보 노출 방지).
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnknown(Exception e) {
+        log.error("Unhandled exception", e);
+        return ResponseEntity
+                .internalServerError()
+                .body(ApiResponse.error(500, "INTERNAL_ERROR", "서버 내부 오류가 발생했습니다"));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,10 @@ spring:
       port: 6379
   kafka:
     bootstrap-servers: localhost:9092
+
+jwt:
+  # 실제 운영에서는 환경변수로 주입해야 함 (application-prod.yml에서 오버라이드)
+  # 학습용이라 기본값을 여기 둠. 최소 32byte 필요.
+  secret: "ticketing-jwt-secret-key-please-change-in-production-32byte-min"
+  expiration-seconds: 86400  # 24시간 (기획안: 장시간 TTL, 단순화)
+


### PR DESCRIPTION
## 구현 내용
- Member 엔티티 및 MemberRepository (JPA)
- JWT 기반 Stateless 인증 (jjwt 0.12.6)
- 회원가입 / 로그인 API
- JwtAuthenticationFilter + SecurityConfig 연동

## 주요 결정
- Refresh token, 소셜 로그인은 비목표(§3.2)에 따라 제외
- Role enum은 EnumType.STRING 사용
- 필터에서 401 직접 반환하지 않고 SecurityConfig에 위임

## 수정 내용
- BaseException 수정 

## 테스트
- [ ] Postman: 회원가입 → 로그인 → 토큰으로 보호된 API 호출
- [ ] 중복 아이디 회원가입 → 409
- [ ] 잘못된 비밀번호 → 401
