### PR TITLE
feat(game): game모듈 구현 - 경기/좌석 마스터 데이터 CRUD

### DIFF
--- a/src/main/java/com/hn/ticketing/game/api/GameController.java
+++ b/src/main/java/com/hn/ticketing/game/api/GameController.java
@@ -1,0 +1,49 @@
+package com.hn.ticketing.game.api;
+
+import com.hn.ticketing.game.api.dto.GameListResponse;
+import com.hn.ticketing.game.api.dto.GameResponse;
+import com.hn.ticketing.game.api.dto.SeatLayoutResponse;
+import com.hn.ticketing.game.domain.GameService;
+import com.hn.ticketing.shared.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+// ── 사용자용 경기 API ──
+// 인증된 사용자가 호출. JWT 필수.
+// auth의 AuthController와 동일한 패턴.
+
+@RestController
+@RequestMapping("/api/games")
+@RequiredArgsConstructor
+public class GameController {
+
+    private final GameService gameService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<GameListResponse>>> getGames(
+            @RequestParam(required = false) LocalDate date) {
+        List<GameListResponse> games = gameService.getGames(date);
+        return ResponseEntity.ok(ApiResponse.success(games));
+    }
+
+    // GET /api/games/{gameId}
+    @GetMapping("/{gameId}")
+    public ResponseEntity<ApiResponse<GameResponse>> getGame(
+            @PathVariable Long gameId) {
+        GameResponse game = gameService.getGame(gameId);
+        return ResponseEntity.ok(ApiResponse.success(game));
+    }
+
+    // GET /api/games/{gameId}/seats
+    // 좌석 배치도 조회. 성능 목표 3,000 req/s.
+    @GetMapping("/{gameId}/seats")
+    public ResponseEntity<ApiResponse<List<SeatLayoutResponse>>> getSeatLayout(
+            @PathVariable Long gameId) {
+        List<SeatLayoutResponse> seatLayout = gameService.getSeatLayout(gameId);
+        return ResponseEntity.ok(ApiResponse.success(seatLayout));
+    }
+}

--- a/src/main/java/com/hn/ticketing/game/api/dto/AdminGameController.java
+++ b/src/main/java/com/hn/ticketing/game/api/dto/AdminGameController.java
@@ -1,0 +1,61 @@
+package com.hn.ticketing.game.api.dto;
+
+import com.hn.ticketing.game.api.dto.CreateGameRequest;
+import com.hn.ticketing.game.api.dto.CreateSectionRequest;
+import com.hn.ticketing.game.domain.AdminGameService;
+import com.hn.ticketing.shared.dto.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+// ── 관리자용 경기 API ──
+// 경기 등록, 구역 등록, 좌석 등록.
+// 현재는 인증만 확인 (JWT 필수).
+// ADMIN 권한 체크는 추후 추가 가능.
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminGameController {
+
+    private final AdminGameService adminGameService;
+
+    // POST /api/admin/games
+    // 경기 등록 + 해당 구장의 모든 좌석에 대해 GameSeat 자동 생성.
+    @PostMapping("/games")
+    public ResponseEntity<ApiResponse<Long>> createGame(
+            @Valid @RequestBody CreateGameRequest request) {
+        Long gameId = adminGameService.createGame(request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success("경기 등록 성공", gameId));
+    }
+
+    // POST /api/admin/sections
+    // 구역 등록.
+    @PostMapping("/sections")
+    public ResponseEntity<ApiResponse<Long>> createSection(
+            @Valid @RequestBody CreateSectionRequest request) {
+        Long sectionId = adminGameService.createSection(request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success("구역 등록 성공", sectionId));
+    }
+
+    // POST /api/admin/sections/{sectionId}/seats
+    // 좌석 일괄 등록.
+    // 예: seatRow=A, startNumber=1, endNumber=20 → A열 1~20번 생성
+    @PostMapping("/sections/{sectionId}/seats")
+    public ResponseEntity<ApiResponse<Integer>> createSeats(
+            @PathVariable Long sectionId,
+            @RequestParam String seatRow,
+            @RequestParam int startNumber,
+            @RequestParam int endNumber) {
+        int count = adminGameService.createSeats(sectionId, seatRow, startNumber, endNumber);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success("좌석 등록 성공", count));
+    }
+}

--- a/src/main/java/com/hn/ticketing/game/api/dto/CreateGameRequest.java
+++ b/src/main/java/com/hn/ticketing/game/api/dto/CreateGameRequest.java
@@ -1,0 +1,32 @@
+package com.hn.ticketing.game.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+// ── 경기 등록 요청 DTO ──
+// POST /api/admin/games 에서 사용.
+public record CreateGameRequest(
+        // stadiumId — 어떤 구장에서 열리는 경기인가.
+        // 본 프로젝트는 단일 구장이지만, API는 범용적으로 설계.
+        @NotNull(message = "구장 ID는 필수입니다")
+        Long stadiumId,
+
+        @NotBlank(message = "경기 제목은 필수입니다")
+        String title,
+
+        @NotNull(message = "경기 날짜는 필수입니다")
+        LocalDate gameDate,
+
+        @NotNull(message = "시작 시간은 필수입니다")
+        LocalTime startTime,
+
+        @NotBlank(message = "홈팀은 필수입니다")
+        String homeTeam,
+
+        @NotBlank(message = "어웨이팀은 필수입니다")
+        String awayTeam
+) {
+}

--- a/src/main/java/com/hn/ticketing/game/api/dto/CreateSectionRequest.java
+++ b/src/main/java/com/hn/ticketing/game/api/dto/CreateSectionRequest.java
@@ -1,0 +1,30 @@
+package com.hn.ticketing.game.api.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+// ── 구역 등록 요청 DTO ──
+// POST /api/admin/sections 에서 사용.
+
+public record CreateSectionRequest(
+
+        @NotNull(message = "구장 ID는 필수입니다")
+        Long stadiumId,
+
+        @NotBlank(message = "구역 이름은 필수입니다")
+        String name,
+
+        // seatGrade — String으로 받아서 Service에서 SeatGrade.valueOf()로 변환.
+        // enum을 직접 받을 수도 있지만, 잘못된 값이 오면
+        // Jackson 역직렬화 에러가 나서 메시지가 불친절하다.
+        // String으로 받고 Service에서 변환하면 친절한 에러 메시지를 줄 수 있다.
+        @NotBlank(message = "좌석 등급은 필수입니다")
+        String seatGrade,
+
+        // totalSeats — 이 구역의 총 좌석 수.
+        // 실제 Seat INSERT와는 별개. 비정규화 필드 용도.
+        @NotNull(message = "총 좌석 수는 필수입니다")
+        @Min(value = 1, message = "좌석 수는 1 이상이어야 합니다")
+        Integer totalSeats
+) {}

--- a/src/main/java/com/hn/ticketing/game/api/dto/GameListResponse.java
+++ b/src/main/java/com/hn/ticketing/game/api/dto/GameListResponse.java
@@ -1,0 +1,27 @@
+package com.hn.ticketing.game.api.dto;
+
+import com.hn.ticketing.game.domain.Game;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+// ── 경기 목록 응답 DTO ──
+public record GameListResponse(
+        Long gameId,
+        String title,
+        LocalDate gameDate,
+        LocalTime startTime,
+        String homeTeam,
+        String awayTeam
+) {
+    public static GameListResponse from(Game game) {
+        return new GameListResponse(
+                game.getId(),
+                game.getTitle(),
+                game.getGameDate(),
+                game.getStartTime(),
+                game.getHomeTeam(),
+                game.getAwayTeam()
+        );
+    }
+}

--- a/src/main/java/com/hn/ticketing/game/api/dto/GameResponse.java
+++ b/src/main/java/com/hn/ticketing/game/api/dto/GameResponse.java
@@ -1,0 +1,28 @@
+package com.hn.ticketing.game.api.dto;
+
+import com.hn.ticketing.game.domain.Game;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record GameResponse(
+        Long GameId,
+        String title,
+        LocalDate gameDate,
+        LocalTime startTime,
+        String homeTeam,
+        String awayTeam,
+        String stadiumName
+) {
+    public static GameResponse from(Game game) {
+        return new GameResponse(
+                game.getId(),
+                game.getTitle(),
+                game.getGameDate(),
+                game.getStartTime(),
+                game.getHomeTeam(),
+                game.getAwayTeam(),
+                game.getStadium().getName()
+        );
+    }
+}

--- a/src/main/java/com/hn/ticketing/game/api/dto/SeatLayoutResponse.java
+++ b/src/main/java/com/hn/ticketing/game/api/dto/SeatLayoutResponse.java
@@ -1,0 +1,39 @@
+package com.hn.ticketing.game.api.dto;
+
+import com.hn.ticketing.game.domain.GameSeat;
+import com.hn.ticketing.game.domain.Seat;
+import com.hn.ticketing.game.domain.Section;
+
+// ── 좌석 배치도 응답 DTO ──
+// GET /api/games/{gameId}/seats 에서 사용.
+//
+// 한 좌석의 정보를 평탄화(flatten)해서 내려준다.
+// 프론트엔드(Postman)에서 좌석 하나의 정보를 한 눈에 볼 수 있도록:
+//   구역명 + 등급 + 열 + 번호 + 가격 + 상태
+//
+// 엔티티 구조: GameSeat → Seat → Section 으로 타고 들어가야 하는데
+// 응답에서는 이 계층을 풀어서 하나의 평면 객체로 만든다.
+public record SeatLayoutResponse(
+        Long gameSeatId,
+        String sectionName,
+        String seatGrade,
+        String seatRow,
+        int seatNumber,
+        int price,
+        String status
+) {
+    public static SeatLayoutResponse from(GameSeat gameSeat) {
+        Seat seat = gameSeat.getSeat();
+        Section section = seat.getSection();
+
+        return new SeatLayoutResponse(
+                gameSeat.getId(),
+                section.getName(),
+                section.getSeatGrade().name(),
+                seat.getSeatRow(),
+                seat.getSeatNumber(),
+                gameSeat.getPrice(),
+                gameSeat.getStatus().name()
+        );
+    }
+}

--- a/src/main/java/com/hn/ticketing/game/domain/AdminGameService.java
+++ b/src/main/java/com/hn/ticketing/game/domain/AdminGameService.java
@@ -64,7 +64,7 @@ public class AdminGameService {
             }
         }
 
-        gameSeatRepository.saveAll(gameSeats);
+        gameSeats.forEach(gameSeatRepository::save);
         return savedGame.getId();
     }
     // ── 구역 등록 ──
@@ -104,7 +104,7 @@ public class AdminGameService {
                     .build());
         }
 
-        seatRepository.saveAll(seats);
+        seats.forEach(seatRepository::save);
         return seats.size();
     }
 

--- a/src/main/java/com/hn/ticketing/game/domain/AdminGameService.java
+++ b/src/main/java/com/hn/ticketing/game/domain/AdminGameService.java
@@ -1,0 +1,122 @@
+package com.hn.ticketing.game.domain;
+
+// ── 관리자용 경기 서비스 ──
+// 경기 등록, 구역 등록, 좌석 일괄 등록.
+// 데이터를 변경하므로 메서드 레벨에 @Transactional.
+
+import com.hn.ticketing.game.api.dto.CreateGameRequest;
+import com.hn.ticketing.game.api.dto.CreateSectionRequest;
+import com.hn.ticketing.game.domain.exception.SectionNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminGameService {
+    private final StadiumRepository stadiumRepository;
+    private final SectionRepository sectionRepository;
+    private final SeatRepository seatRepository;
+    private final GameRepository gameRepository;
+    private final GameSeatRepository gameSeatRepository;
+
+    // ── 경기 등록 ──
+    // 경기를 만들고, 해당 구장의 모든 좌석에 대해 GameSeat을 자동 생성.
+    // 이 API가 있어야 테스트할 데이터가 생긴다.
+    //
+    // 흐름:
+    //   1) Stadium 조회
+    //   2) Game INSERT
+    //   3) Stadium의 모든 Section 조회
+    //   4) 각 Section의 모든 Seat 조회
+    //   5) 각 Seat에 대해 GameSeat 생성 (등급별 기본 가격)
+    //   6) GameSeat 일괄 INSERT
+    @Transactional
+    public Long createGame(CreateGameRequest request) {
+        Stadium stadium = stadiumRepository.findById(request.stadiumId())
+                .orElseThrow(() -> new IllegalArgumentException("구장을 찾을 수 없습니다"));
+
+        Game game = Game.builder()
+                .stadium(stadium)
+                .title(request.title())
+                .gameDate(request.gameDate())
+                .startTime(request.startTime())
+                .homeTeam(request.homeTeam())
+                .awayTeam(request.awayTeam())
+                .build();
+
+        Game savedGame = gameRepository.save(game);
+
+        // 구장의 모든 구역 → 모든 좌석 → GameSeat 생성
+        List<Section> sections = sectionRepository.findByStadiumId(stadium.getId());
+        List<GameSeat> gameSeats = new ArrayList<>();
+
+        for (Section section : sections) {
+            int price = getDefaultPrice(section.getSeatGrade());
+            List<Seat> seats = seatRepository.findBySectionId(section.getId());
+
+            for (Seat seat : seats) {
+                gameSeats.add(GameSeat.createAvailable(savedGame, seat, price));
+            }
+        }
+
+        gameSeatRepository.saveAll(gameSeats);
+        return savedGame.getId();
+    }
+    // ── 구역 등록 ──
+    @Transactional
+    public Long createSection(CreateSectionRequest request) {
+        Stadium stadium = stadiumRepository.findById(request.stadiumId())
+                .orElseThrow(() -> new IllegalArgumentException("구장을 찾을 수 없습니다"));
+
+        SeatGrade grade = SeatGrade.valueOf(request.seatGrade());
+
+        Section section = Section.builder()
+                .stadium(stadium)
+                .name(request.name())
+                .seatGrade(grade)
+                .totalSeats(request.totalSeats())
+                .build();
+
+        Section saved = sectionRepository.save(section);
+        return saved.getId();
+    }
+
+    // ── 좌석 일괄 등록 ──
+    // 특정 구역에 좌석 N개를 한 번에 생성.
+    // seatRow와 시작 번호, 끝 번호를 받아서 생성.
+    // 예: createSeats(sectionId, "A", 1, 20) → A열 1~20번 좌석 20개
+    @Transactional
+    public int createSeats(Long sectionId, String seatRow, int startNumber, int endNumber) {
+        Section section = sectionRepository.findById(sectionId)
+                .orElseThrow(SectionNotFoundException::new);
+
+        List<Seat> seats = new ArrayList<>();
+        for (int i = startNumber; i <= endNumber; i++) {
+            seats.add(Seat.builder()
+                    .section(section)
+                    .seatRow(seatRow)
+                    .seatNumber(i)
+                    .build());
+        }
+
+        seatRepository.saveAll(seats);
+        return seats.size();
+    }
+
+    // ── 등급별 기본 가격 ──
+    // 경기 등록 시 GameSeat에 넣을 기본 가격.
+    // 실제 서비스면 DB에서 관리하겠지만,
+    // 이 프로젝트에서는 하드코딩으로 충분.
+    private int getDefaultPrice(SeatGrade grade) {
+        return switch (grade) {
+            case PREMIUM -> 50_000;
+            case STANDARD -> 30_000;
+            case OUTFIELD -> 15_000;
+        };
+    }
+}

--- a/src/main/java/com/hn/ticketing/game/domain/Game.java
+++ b/src/main/java/com/hn/ticketing/game/domain/Game.java
@@ -1,0 +1,77 @@
+package com.hn.ticketing.game.domain;
+
+import com.hn.ticketing.shared.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+// ── 경기 엔티티 ──
+// KBO 경기 한 건. 관리자가 등록한다.
+// 사용자는 경기 목록을 조회하고, 특정 경기의 좌석을 예매한다.
+
+// 왜 homeTeam/awayTeam을 String으로 두나:
+//   Team 엔티티를 따로 만들면 도메인 복잡도만 올라가고
+//   이 프로젝트의 핵심(동시성/정합성)과는 무관.
+//   기획안 3.5: "다구단 통합은 비목표"
+//
+// 왜 gameDate와 startTime을 분리하나:
+//   LocalDate + LocalTime으로 나누면
+//   "날짜별 경기 목록 조회" 쿼리에서 gameDate만으로 WHERE 가능.
+//   LocalDateTime이면 시간 부분을 잘라내는 변환이 필요해서 인덱스 활용이 어려움.
+
+@Entity
+@Table(name = "game")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Game extends BaseEntity {
+    // ── 연관관계 ──
+
+    // 경기가 열리는 구장.
+    // 본 프로젝트는 단일 구장이지만 FK로 연결해둔다.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stadium_id", nullable = false)
+    private Stadium stadium;
+
+    // ── 필드 ──
+
+    // 경기 제목. 예: "2026 KBO 한국시리즈 1차전"
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    // 경기 날짜. 예: 2026-04-15
+    // LocalDate — 날짜만. 시간 정보 없음.
+    @Column(name = "game_date", nullable = false)
+    private LocalDate gameDate;
+
+    // 경기 시작 시각. 예: 18:30
+    // LocalTime — 시각만. 날짜 정보 없음.
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    // 홈팀 이름. 예: "한화 이글스"
+    // Team 엔티티 대신 단순 문자열.
+    @Column(name = "home_team", nullable = false, length = 30)
+    private String homeTeam;
+
+    // 어웨이팀 이름. 예: "삼성 라이온즈"
+    @Column(name = "away_team", nullable = false, length = 30)
+    private String awayTeam;
+
+    // ── 생성자 ──
+
+    @Builder
+    private Game(Stadium stadium, String title, LocalDate gameDate,
+                 LocalTime startTime, String homeTeam, String awayTeam) {
+        this.stadium = stadium;
+        this.title = title;
+        this.gameDate = gameDate;
+        this.startTime = startTime;
+        this.homeTeam = homeTeam;
+        this.awayTeam = awayTeam;
+    }
+}

--- a/src/main/java/com/hn/ticketing/game/domain/GameRepository.java
+++ b/src/main/java/com/hn/ticketing/game/domain/GameRepository.java
@@ -1,0 +1,20 @@
+package com.hn.ticketing.game.domain;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+// ── 경기 리포지토리 인터페이스 ──
+public interface GameRepository {
+
+    Game save(Game game);
+
+    Optional<Game> findById(Long id);
+
+    // 특정 날짜의 경기 목록
+    // API : GET /api/games?date=2026-04-15
+    List<Game> findByGameDate(LocalDate gameDate);
+
+    // 전체 경기 목록
+    // 날짜 필터 없이 조회
+    List<Game> findAll();
+}

--- a/src/main/java/com/hn/ticketing/game/domain/GameSeat.java
+++ b/src/main/java/com/hn/ticketing/game/domain/GameSeat.java
@@ -1,0 +1,91 @@
+package com.hn.ticketing.game.domain;
+
+// ── 경기별 좌석 엔티티 (핵심) ──
+// Game × Seat의 교차 테이블. 경기마다 좌석별 가격과 상태를 관리.
+//
+// 기획안 7.2:
+//   같은 "1루 내야 A열 15번" 좌석이라도
+//   개막전에는 30,000원, 평일 경기에는 15,000원일 수 있다.
+//   Seat에 가격을 넣으면 경기별 가격 차이를 표현할 수 없다.
+//
+// status 필드에 대한 중요한 설계 판단:
+//   실시간 점유 상태(HELD)는 Redis에서 판단한다 (SEAT_HOLD_DESIGN 참조).
+//   이 컬럼은 "최종 확정 상태"를 MySQL에 영속적으로 기록하는 역할.
+//   즉, Redis = 실시간 판단용, MySQL = 영구 기록용.
+//   두 저장소가 각자 다른 의미의 상태를 담는다 (기획안 §7.4).
+//
+// @Table 설정:
+//   uniqueConstraints — 같은 경기에 같은 좌석 두 번 등록 방지.
+//     좌석 점유 설계서 3.3: "MySQL 유니크 제약이 정합성 최종 방어선"
+//   indexes — 경기별 좌석 목록 조회가 핵심 쿼리이므로 game_id 인덱스 필수.
+//     이 인덱스 없으면 좌석 배치도 조회 시 풀 테이블 스캔.
+
+import com.hn.ticketing.shared.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "game_seats", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_game_seat",
+                columnNames = {"game_id", "seat_id"}
+        )
+}, indexes = {
+        @Index(name = "idx_game_seat_id", columnList = "game_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GameSeat extends BaseEntity {
+    // ── 연관관계 ──
+
+    // 어떤 경기의 좌석인가.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id", nullable = false)
+    private Game game;
+
+    // 어떤 물리 좌석인가.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_id", nullable = false)
+    private Seat seat;
+
+    // ── 필드 ──
+
+    // 이 경기에서 이 좌석의 가격 (원 단위).
+    // int → 약 21억까지 표현 가능. 티켓 가격으로 충분.
+    @Column(name = "price", nullable = false)
+    private int price;
+
+    // 좌석 상태.
+    // AVAILABLE → HELD → CONFIRMED / CANCELLED
+    // 관리자 초기값은 AVAILABLE.
+    // 실시간 점유 판단은 Redis, 여기는 영구 기록용.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private GameSeatStatus status;
+
+    // ── 생성자 ──
+
+    @Builder
+    private GameSeat(Game game, Seat seat, int price, GameSeatStatus status) {
+        this.game = game;
+        this.seat = seat;
+        this.price = price;
+        this.status = status;
+    }
+
+    // ── 정적 팩토리 메서드 ──
+    // 경기 등록 시 모든 좌석을 AVAILABLE + 등급별 가격으로 일괄 생성할 때 사용.
+    // Builder보다 의도가 명확하다.
+
+    public static GameSeat createAvailable(Game game, Seat seat, int price) {
+        return GameSeat.builder()
+                .game(game)
+                .seat(seat)
+                .price(price)
+                .status(GameSeatStatus.AVAILABLE)
+                .build();
+    }
+}

--- a/src/main/java/com/hn/ticketing/game/domain/GameSeatRepository.java
+++ b/src/main/java/com/hn/ticketing/game/domain/GameSeatRepository.java
@@ -6,8 +6,6 @@ import java.util.Optional;
 public interface GameSeatRepository {
     GameSeat save(GameSeat gameSeat);
 
-    List<GameSeat> saveAll(List<GameSeat> gameSeats);
-
     Optional<GameSeat> findById(Long id);
 
     // 특정 경기의 전체 좌석 조회

--- a/src/main/java/com/hn/ticketing/game/domain/GameSeatRepository.java
+++ b/src/main/java/com/hn/ticketing/game/domain/GameSeatRepository.java
@@ -1,0 +1,15 @@
+package com.hn.ticketing.game.domain;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GameSeatRepository {
+    GameSeat save(GameSeat gameSeat);
+
+    List<GameSeat> saveAll(List<GameSeat> gameSeats);
+
+    Optional<GameSeat> findById(Long id);
+
+    // 특정 경기의 전체 좌석 조회
+    List<GameSeat> findByGameId(Long gameId);
+}

--- a/src/main/java/com/hn/ticketing/game/domain/GameSeatStatus.java
+++ b/src/main/java/com/hn/ticketing/game/domain/GameSeatStatus.java
@@ -1,0 +1,17 @@
+package com.hn.ticketing.game.domain;
+
+// ── 경기별 좌석의 "판매 가능 여부" enum ──
+//
+// 주의: 이건 좌석의 "점유 상태"(AVAILABLE/HELD/CONFIRMED)와 다르다.
+// 점유 상태는 Redis에만 존재하고 DB에는 없다.
+//
+// GameSeatStatus는 "이 좌석을 애초에 판매 대상으로 열었는가"를 나타낸다.
+// 예: 시야 불량석, 방송 카메라석 → UNAVAILABLE로 잠금.
+//     이미 시즌권으로 팔린 좌석 → SOLD_OUT.
+//
+// 관리자가 경기 등록 시 설정하는 값이다. 실시간으로 바뀌지 않는다.
+public enum GameSeatStatus {
+    AVAILABLE,      // 판매 가능 — 일반 사용자가 점유 시도 가능
+    UNAVAILABLE,    // 판매 불가 — 시야 불량, 카메라석 등
+    SOLD_OUT;       // 매진 — 시즌권 등으로 이미 배정됨
+}

--- a/src/main/java/com/hn/ticketing/game/domain/GameSeatStatus.java
+++ b/src/main/java/com/hn/ticketing/game/domain/GameSeatStatus.java
@@ -1,17 +1,21 @@
 package com.hn.ticketing.game.domain;
 
-// ── 경기별 좌석의 "판매 가능 여부" enum ──
+// ── 경기별 좌석 상태 enum ──
+// GameSeat 엔티티에서 사용.
 //
-// 주의: 이건 좌석의 "점유 상태"(AVAILABLE/HELD/CONFIRMED)와 다르다.
-// 점유 상태는 Redis에만 존재하고 DB에는 없다.
+// 주의: 실시간 점유 판단은 Redis 키 존재 여부로 한다 (SEAT_HOLD_DESIGN 참조).
+// 이 enum은 MySQL에 "최종 확정 상태"를 영속적으로 기록하는 역할.
 //
-// GameSeatStatus는 "이 좌석을 애초에 판매 대상으로 열었는가"를 나타낸다.
-// 예: 시야 불량석, 방송 카메라석 → UNAVAILABLE로 잠금.
-//     이미 시즌권으로 팔린 좌석 → SOLD_OUT.
-//
-// 관리자가 경기 등록 시 설정하는 값이다. 실시간으로 바뀌지 않는다.
+// 상태 전이:
+//   AVAILABLE → HELD → CONFIRMED (결제 성공)
+//                   → AVAILABLE  (TTL 만료 / 자진 해제)
+//   CONFIRMED → CANCELLED (예매 취소)
+//   CANCELLED → AVAILABLE (취소 후 재오픈)
+
 public enum GameSeatStatus {
-    AVAILABLE,      // 판매 가능 — 일반 사용자가 점유 시도 가능
-    UNAVAILABLE,    // 판매 불가 — 시야 불량, 카메라석 등
-    SOLD_OUT;       // 매진 — 시즌권 등으로 이미 배정됨
+
+    AVAILABLE,   // 예매 가능
+    HELD,        // 임시 점유 중 (Redis TTL 만료 시 AVAILABLE로 복귀)
+    CONFIRMED,   // 결제 완료, 영구 확정
+    CANCELLED;   // 예매 취소됨
 }

--- a/src/main/java/com/hn/ticketing/game/domain/GameService.java
+++ b/src/main/java/com/hn/ticketing/game/domain/GameService.java
@@ -1,0 +1,62 @@
+package com.hn.ticketing.game.domain;
+
+import com.hn.ticketing.game.api.dto.GameListResponse;
+import com.hn.ticketing.game.api.dto.GameResponse;
+import com.hn.ticketing.game.api.dto.SeatLayoutResponse;
+import com.hn.ticketing.game.domain.exception.GameNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+// ── 사용자용 경기 서비스 ──
+// 경기 조회, 좌석 배치도 조회.
+// 데이터를 변경하지 않으므로 클래스 레벨에 readOnly = true.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GameService {
+    private final GameRepository gameRepository;
+    private final GameSeatRepository gameSeatRepository;
+
+    // ── 경기 목록 조회 ──
+    // date 파라미터가 있으면 해당 날짜, 없으면 전체.
+    public List<GameListResponse> getGames(LocalDate date) {
+        List<Game> games;
+        if (date != null) {
+            games = gameRepository.findByGameDate(date);
+        } else {
+            games = gameRepository.findAll();
+        }
+        return games.stream()
+                .map(GameListResponse::from)
+                .toList();
+    }
+    // ── 경기 상세 조회 ──
+    public GameResponse getGame(Long gameId) {
+        Game game = gameRepository.findById(gameId).orElseThrow(GameNotFoundException::new);
+        return GameResponse.from(game);
+    }
+
+    // ── 좌석 배치도 조회 ──
+    // 특정 경기의 전체 좌석 + 상태.
+    // 성능 목표: 3,000 req/s, p99 200ms 이하.
+    //
+    // 현재는 MySQL에서만 조회.
+    // 3단계에서 Redis 점유 상태를 합치는 로직이 추가된다.
+    // 지금은 GameSeat.status만으로 응답.
+    public List<SeatLayoutResponse> getSeatLayout(Long gameId) {
+        // 경기 존재 여부만 먼저 확인. 없으면 404.
+        gameRepository.findById(gameId)
+                .orElseThrow(GameNotFoundException::new);
+        List<GameSeat> gameSeats = gameSeatRepository.findByGameId(gameId);
+
+        return gameSeats.stream()
+                .map(SeatLayoutResponse::from)
+                .toList();
+    }
+
+
+}

--- a/src/main/java/com/hn/ticketing/game/domain/Seat.java
+++ b/src/main/java/com/hn/ticketing/game/domain/Seat.java
@@ -1,0 +1,58 @@
+package com.hn.ticketing.game.domain;
+
+import com.hn.ticketing.shared.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// ── 물리 좌석 엔티티 ──
+// 구장에 물리적으로 존재하는 좌석 하나하나.
+// 경기와 무관하게 항상 존재한다. (의자는 안 바뀌니까)
+//
+// 기획안 7.2 — Seat과 GameSeat을 분리한 이유:
+//   "물리 좌석은 바뀌지 않지만 경기마다 가격·상태가 다르다.
+//    합쳐두면 한 좌석이 여러 경기에 동시 존재하는 걸 모델링할 수 없다."
+//   Seat = 물리적 실체 (불변), GameSeat = 경기별 인스턴스 (가변).
+//
+// Seat은 한 번 INSERT 후 거의 변경되지 않는 불변 데이터.
+@Entity
+@Getter
+@Table(name = "seat", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_section_row_number",
+                columnNames = {"section_id", "seat_row", "seat_number"}
+        )
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Seat extends BaseEntity {
+
+    // ── 연관관계 ──
+
+    // 이 좌석이 속한 구역.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "section_id", nullable = false)
+    private Section section;
+
+    // ── 필드 ──
+
+    // 열 식별자. 예: "A", "B", "AA"
+    // String인 이유: 일부 구장에서 AA, BB 같은 문자열 열 번호를 쓴다.
+    @Column(name = "seat_row", nullable = false, length = 10)
+    private String seatRow;
+
+    // 좌석 번호. 예: 1, 2, 3 ...
+    // 같은 열 안에서의 순번. 이건 항상 숫자라 int.
+    @Column(name = "seat_number", nullable = false)
+    private int seatNumber;
+
+    // ── 생성자 ──
+
+    @Builder
+    private Seat(Section section, String seatRow, int seatNumber) {
+        this.section = section;
+        this.seatRow = seatRow;
+        this.seatNumber = seatNumber;
+    }
+}

--- a/src/main/java/com/hn/ticketing/game/domain/SeatGrade.java
+++ b/src/main/java/com/hn/ticketing/game/domain/SeatGrade.java
@@ -1,34 +1,16 @@
 package com.hn.ticketing.game.domain;
 
 // ── 좌석 등급 enum ──
-// Section(구역)마다 하나의 등급이 붙는다.
-// 한화생명 볼파크 기준으로 대표적인 등급만 정의.
-// 등급별 기본 가격은 여기가 아니라 GameSeat에서 경기마다 따로 매긴다.
-// (같은 테이블석이라도 한국시리즈와 평일 경기의 가격이 다르니까)
+// 가격 정책의 기준 단위. Section에 귀속된다.
+// 같은 구역의 좌석은 모두 같은 등급.
+//
+// 의도적으로 3개로 단순화했다.
+// 이 프로젝트의 핵심은 좌석 등급 세분화가 아니라 동시성/정합성이므로
+// 등급이 많으면 시드 데이터와 테스트 복잡도만 올라간다.
+
 public enum SeatGrade {
 
-    CENTRAL("중앙 지정석"),
-    CENTRAL_TABLE("중앙 탁자석"),
-    CENTRAL_WHEELCHAIR("중앙 휠체어석"),
-    CATCHER_BEHIND("포수 후면석"),
-    INFIELD_A("내야 지정석A"),
-    INFIELD_B("내야 지정석B"),
-    INFIELD_TABLE("내야 탁자석(4층)"),
-    INFIELD_WHEELCHAIR("내야 휠체어석"),
-    SPLASH_JACUZZI("스플래쉬 자쿠지(인피니티 풀)"),
-    SPLASH_CARAVAN("스플래쉬 카라반(인피니티 풀)"),
-    CASS_ZONE("카스존(응원단석)"),
-    INNINGS_VIP("이닝스 VIP 바 & 룸/테라스"),
-    SKY_BOX("스카이박스");
-
-    private final String displayName;
-
-    // ── 생성자 ──
-    // enum 생성자는 private이 기본. 외부에서 new 불가.
-    SeatGrade(String displayName) {
-        this.displayName = displayName;
-    }
-    public String getDisplayName() {
-        return displayName;
-    }
+    PREMIUM,    // 테이블석, VIP 등 프리미엄 구역
+    STANDARD,   // 1루/3루 내야 지정석
+    OUTFIELD;   // 외야 자유석
 }

--- a/src/main/java/com/hn/ticketing/game/domain/SeatGrade.java
+++ b/src/main/java/com/hn/ticketing/game/domain/SeatGrade.java
@@ -1,0 +1,34 @@
+package com.hn.ticketing.game.domain;
+
+// ── 좌석 등급 enum ──
+// Section(구역)마다 하나의 등급이 붙는다.
+// 한화생명 볼파크 기준으로 대표적인 등급만 정의.
+// 등급별 기본 가격은 여기가 아니라 GameSeat에서 경기마다 따로 매긴다.
+// (같은 테이블석이라도 한국시리즈와 평일 경기의 가격이 다르니까)
+public enum SeatGrade {
+
+    CENTRAL("중앙 지정석"),
+    CENTRAL_TABLE("중앙 탁자석"),
+    CENTRAL_WHEELCHAIR("중앙 휠체어석"),
+    CATCHER_BEHIND("포수 후면석"),
+    INFIELD_A("내야 지정석A"),
+    INFIELD_B("내야 지정석B"),
+    INFIELD_TABLE("내야 탁자석(4층)"),
+    INFIELD_WHEELCHAIR("내야 휠체어석"),
+    SPLASH_JACUZZI("스플래쉬 자쿠지(인피니티 풀)"),
+    SPLASH_CARAVAN("스플래쉬 카라반(인피니티 풀)"),
+    CASS_ZONE("카스존(응원단석)"),
+    INNINGS_VIP("이닝스 VIP 바 & 룸/테라스"),
+    SKY_BOX("스카이박스");
+
+    private final String displayName;
+
+    // ── 생성자 ──
+    // enum 생성자는 private이 기본. 외부에서 new 불가.
+    SeatGrade(String displayName) {
+        this.displayName = displayName;
+    }
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/main/java/com/hn/ticketing/game/domain/SeatRepository.java
+++ b/src/main/java/com/hn/ticketing/game/domain/SeatRepository.java
@@ -9,11 +9,8 @@ public interface SeatRepository {
 
     Seat save(Seat seat);
 
-    // 여러 좌석을 한 번에 저장.
-    // 관리자가 구역에 좌석을 일괄 등록할 때 사용.
-    // 좌석 50개를 하나씩 save()하면 INSERT 50번.
-    // saveAll()이면 JPA가 배치 INSERT로 최적화할 수 있다.
-    List<Seat> saveAll(List<Seat> seats);
+
+
 
     // 특정 구역의 모든 좌석 조회.
     // 경기 등록 시 "이 구장의 모든 좌석"을 가져와서 GameSeat을 생성해야 하므로.

--- a/src/main/java/com/hn/ticketing/game/domain/SeatRepository.java
+++ b/src/main/java/com/hn/ticketing/game/domain/SeatRepository.java
@@ -1,0 +1,21 @@
+package com.hn.ticketing.game.domain;
+
+import java.util.List;
+
+// ── 좌석 리포지토리 인터페이스 ──
+// 좌석 저장 + 구역별 좌석 조회.
+
+public interface SeatRepository {
+
+    Seat save(Seat seat);
+
+    // 여러 좌석을 한 번에 저장.
+    // 관리자가 구역에 좌석을 일괄 등록할 때 사용.
+    // 좌석 50개를 하나씩 save()하면 INSERT 50번.
+    // saveAll()이면 JPA가 배치 INSERT로 최적화할 수 있다.
+    List<Seat> saveAll(List<Seat> seats);
+
+    // 특정 구역의 모든 좌석 조회.
+    // 경기 등록 시 "이 구장의 모든 좌석"을 가져와서 GameSeat을 생성해야 하므로.
+    List<Seat> findBySectionId(Long sectionId);
+}

--- a/src/main/java/com/hn/ticketing/game/domain/Section.java
+++ b/src/main/java/com/hn/ticketing/game/domain/Section.java
@@ -1,0 +1,67 @@
+package com.hn.ticketing.game.domain;
+
+import com.hn.ticketing.shared.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// ── 구역 엔티티 ──
+// 구장 안의 구역. 예: "1루 내야 A구역", "3루 외야"
+// 좌석 등급(SeatGrade)의 단위. 같은 구역 = 같은 등급 = 같은 기본 가격.
+
+//
+// 왜 Seat과 분리하나:
+//   개별 좌석(Seat)은 물리적 위치(열, 번호)만 가지고,
+//   등급·가격 같은 정책 정보는 Section이 가짐.
+//   좌석 1만 개에 각각 등급을 넣으면 데이터 중복이고
+//   정책 변경 시 1만 행 UPDATE.
+//
+// 관계: Stadium (1) ←── (N) Section (1) ←── (N) Seat
+
+@Entity
+@Table(name = "section")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Section extends BaseEntity {
+
+    // 이 구역이 속한 구장
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stadium_id", nullable = false)
+    private Stadium stadium;
+
+    // 필드
+    // 구역 이름. 예: "1루 내야 A구역"
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    // 좌석 등급
+    @Enumerated(EnumType.STRING)
+    @Column(name = "seat_grade", nullable = false, length = 20)
+    private SeatGrade seatGrade;
+
+    // 이 구역의 총 좌석 수
+    // 비정규화 필드. Seat 테이블 COUNT로도 구할 수 있지만
+    // 조회 때마다 COUNT 쿼리를 날리는 건 비효율.
+    // 경기 목록에서 "잔여석 수" 요약할 때 빠르게 쓸 수 있다.
+    @Column(name = "total_seats", nullable = false)
+    private int totalSeats;
+
+    // 이 구역에 속한 좌석 목록
+    @OneToMany(mappedBy = "section")
+    private List<Seat> seats = new ArrayList<>();
+
+    // ── 생성자 ──
+
+    @Builder
+    private Section(Stadium stadium, String name, SeatGrade seatGrade, int totalSeats) {
+        this.stadium = stadium;
+        this.name = name;
+        this.seatGrade = seatGrade;
+        this.totalSeats = totalSeats;
+    }
+}

--- a/src/main/java/com/hn/ticketing/game/domain/SectionRepository.java
+++ b/src/main/java/com/hn/ticketing/game/domain/SectionRepository.java
@@ -1,0 +1,14 @@
+package com.hn.ticketing.game.domain;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SectionRepository {
+    Section save(Section section);
+
+    Optional<Section> findById(Long id);
+
+    // 특정 구장의 모든 구역 조회
+    // 좌석 배치도 조회 시 구장 -> 구역 -> 좌석 순으로 탐색하므로 필요
+    List<Section> findByStadiumId(Long stadiumId);
+}

--- a/src/main/java/com/hn/ticketing/game/domain/Stadium.java
+++ b/src/main/java/com/hn/ticketing/game/domain/Stadium.java
@@ -1,0 +1,55 @@
+package com.hn.ticketing.game.domain;
+
+import com.hn.ticketing.shared.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// ── 구장 엔티티 ──
+// 이 프로젝트는 대전 신구장(한화생명 이글스파크) 단일 구장.
+//
+// 왜 단일 구장인데 엔티티를 만드나:
+//   하드코딩하면 구장 정보를 바꿀 때 코드 수정이 필요.
+//   엔티티로 두면 DB INSERT 한 번으로 끝.
+//   또한 Section이 stadium_id FK를 가지므로 정규화된 구조 유지.
+@Entity
+@Table(name = "stadium")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Stadium extends BaseEntity {
+
+    // ── 필드 ──
+
+    // 구장 이름. 예: "대전 한화생명 이글스파크"
+    // nullable = false → DB 레벨 NOT NULL 제약.
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    // 구장 주소.
+    // length = 200 → 주소는 길 수 있으므로 넉넉히.
+    @Column(name = "address", nullable = false, length = 200)
+    private String address;
+
+    // ── 연관관계 ──
+
+    // 이 구장에 속한 구역 목록.
+    //   양방향 관계를 거는 이유:
+    //   Stadium에서 구역 목록을 조회할 일이 있으므로 (좌석 배치도 등).
+    @OneToMany(mappedBy = "stadium")
+    private List<Section> sections = new ArrayList<>();
+
+    // ── 생성자 ──
+    @Builder
+    private Stadium(String name, String address) {
+        this.name = name;
+        this.address = address;
+    }
+}

--- a/src/main/java/com/hn/ticketing/game/domain/StadiumRepository.java
+++ b/src/main/java/com/hn/ticketing/game/domain/StadiumRepository.java
@@ -1,0 +1,10 @@
+package com.hn.ticketing.game.domain;
+
+
+import java.util.Optional;
+
+public interface StadiumRepository {
+    Stadium save(Stadium stadium);
+
+    Optional<Stadium> findById(Long id);
+}

--- a/src/main/java/com/hn/ticketing/game/domain/exception/GameNotFoundException.java
+++ b/src/main/java/com/hn/ticketing/game/domain/exception/GameNotFoundException.java
@@ -1,0 +1,10 @@
+package com.hn.ticketing.game.domain.exception;
+
+import com.hn.ticketing.shared.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class GameNotFoundException extends BaseException {
+    public GameNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "GAME_NOT_FOUND", "경기를 찾을 수 없습니다");
+    }
+}

--- a/src/main/java/com/hn/ticketing/game/domain/exception/SectionNotFoundException.java
+++ b/src/main/java/com/hn/ticketing/game/domain/exception/SectionNotFoundException.java
@@ -1,0 +1,10 @@
+package com.hn.ticketing.game.domain.exception;
+
+import com.hn.ticketing.shared.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class SectionNotFoundException extends BaseException {
+    public SectionNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "SECTION_NOT_FOUND", "구역을 찾을 수 없습니다");
+    }
+}

--- a/src/main/java/com/hn/ticketing/game/infrastructure/JpaGameRepository.java
+++ b/src/main/java/com/hn/ticketing/game/infrastructure/JpaGameRepository.java
@@ -1,0 +1,18 @@
+package com.hn.ticketing.game.infrastructure;
+
+import com.hn.ticketing.game.domain.Game;
+import com.hn.ticketing.game.domain.GameRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface JpaGameRepository extends GameRepository, JpaRepository<Game, Long> {
+
+    // findByGameDate → WHERE game_date = ?
+    // Game 엔티티에서 gameDate를 LocalDate로 분리했기 때문에
+    // 날짜 비교가 단순 등호(=)로 가능하다.
+    // LocalDateTime이었으면 BETWEEN이나 DATE() 함수를 써야 했을 것.
+    @Override
+    List<Game> findByGameDate(LocalDate gameDate);
+}

--- a/src/main/java/com/hn/ticketing/game/infrastructure/JpaGameSeatRepository.java
+++ b/src/main/java/com/hn/ticketing/game/infrastructure/JpaGameSeatRepository.java
@@ -1,0 +1,14 @@
+package com.hn.ticketing.game.infrastructure;
+
+import com.hn.ticketing.game.domain.GameSeat;
+import com.hn.ticketing.game.domain.GameSeatRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface JpaGameSeatRepository extends GameSeatRepository, JpaRepository<GameSeat, Long> {
+
+    // 좌석 2만 개 중 해당 경기 좌석만 빠르게 조회.
+    @Override
+    List<GameSeat> findByGameId(Long gameId);
+}

--- a/src/main/java/com/hn/ticketing/game/infrastructure/JpaSeatRepository.java
+++ b/src/main/java/com/hn/ticketing/game/infrastructure/JpaSeatRepository.java
@@ -1,0 +1,14 @@
+package com.hn.ticketing.game.infrastructure;
+
+import com.hn.ticketing.game.domain.Seat;
+import com.hn.ticketing.game.domain.SeatRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface JpaSeatRepository extends SeatRepository, JpaRepository<Seat, Long> {
+
+    // findBySectionId → WHERE section_id = ?
+    @Override
+    List<Seat> findBySectionId(Long sectionId);
+}

--- a/src/main/java/com/hn/ticketing/game/infrastructure/JpaSectionRepository.java
+++ b/src/main/java/com/hn/ticketing/game/infrastructure/JpaSectionRepository.java
@@ -1,0 +1,12 @@
+package com.hn.ticketing.game.infrastructure;
+
+import com.hn.ticketing.game.domain.Section;
+import com.hn.ticketing.game.domain.SectionRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface JpaSectionRepository extends SectionRepository, JpaRepository<Section, Long> {
+    @Override
+    List<Section> findByStadiumId(Long stadiumId);
+}

--- a/src/main/java/com/hn/ticketing/game/infrastructure/JpaStadiumRepository.java
+++ b/src/main/java/com/hn/ticketing/game/infrastructure/JpaStadiumRepository.java
@@ -1,0 +1,23 @@
+package com.hn.ticketing.game.infrastructure;
+
+import com.hn.ticketing.game.domain.Stadium;
+import com.hn.ticketing.game.domain.StadiumRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// ── JPA 구장 리포지토리 구현 ──
+//
+// 왜 두 개를 동시에 extends 하나:
+//
+// 1) StadiumRepository (도메인 인터페이스)
+//    → Service가 의존하는 계약. save(), findById() 메서드 시그니처 정의.
+//
+// 2) JpaRepository<Stadium, Long> (Spring Data JPA)
+//    → Spring이 런타임에 구현체를 자동 생성해준다.
+//    → save(), findById(), findAll() 등이 이미 구현되어 있다.
+//
+// 이 두 개를 합치면:
+//    Spring이 자동 생성한 JPA 구현체가 곧 도메인 인터페이스의 구현체가 된다.
+//    별도 클래스에 @Repository 붙이고 메서드 하나하나 구현할 필요 없음.
+public interface JpaStadiumRepository extends StadiumRepository, JpaRepository<Stadium, Long> {
+
+}

--- a/src/main/java/com/hn/ticketing/shared/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/hn/ticketing/shared/config/KafkaConsumerConfig.java
@@ -15,7 +15,7 @@ import java.util.Map;
 @Configuration
 public class KafkaConsumerConfig {
 
-    @Value("${kafka.bootstrap-servers}")
+    @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
 
     @Bean

--- a/src/main/java/com/hn/ticketing/shared/config/KafkaProducerConfig.java
+++ b/src/main/java/com/hn/ticketing/shared/config/KafkaProducerConfig.java
@@ -15,7 +15,7 @@ import java.util.Map;
 @Configuration
 public class KafkaProducerConfig {
 
-    @Value("${kafka.bootstrap-servers}")
+    @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
 
     @Bean

--- a/src/main/java/com/hn/ticketing/shared/config/RedisConfig.java
+++ b/src/main/java/com/hn/ticketing/shared/config/RedisConfig.java
@@ -11,10 +11,10 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String host;
 
-    @Value("${spring.redis.port}")
+    @Value("${spring.data.redis.port}")
     private int port;
 
     @Bean


### PR DESCRIPTION
## Summary
- 2단계 game 모듈 구현 — 경기/좌석 마스터 데이터 CRUD
- 이 데이터가 있어야 3단계(대기열, 좌석 점유, 예매, 결제)가 가능해짐

### 추가된 것
- **엔티티 5개**: Stadium, Section, Seat, Game, GameSeat
- **enum 2개**: SeatGrade(PREMIUM/STANDARD/OUTFIELD), GameSeatStatus(AVAILABLE/HELD/CONFIRMED/CANCELLED)
- **리포지토리**: 도메인 인터페이스 5개 + JPA 구현 5개 (DIP 패턴, auth 모듈과 동일)
- **서비스**: GameService(조회), AdminGameService(등록)
- **API 엔드포인트**:
  - `GET /api/games` — 경기 목록 조회 (날짜 필터 가능)
  - `GET /api/games/{gameId}` — 경기 상세 조회
  - `GET /api/games/{gameId}/seats` — 좌석 배치도 조회
  - `POST /api/admin/games` — 경기 등록 (GameSeat 자동 생성)
  - `POST /api/admin/sections` — 구역 등록
  - `POST /api/admin/sections/{sectionId}/seats` — 좌석 일괄 등록
- **예외**: GameNotFoundException(404), SectionNotFoundException(404)

### 설계 판단
- **Seat ↔ GameSeat 분리**: 물리 좌석(불변)과 경기별 좌석(가변)을 분리하여 경기마다 독립적인 가격/상태 관리
- **GameSeatStatus**: 실시간 점유 판단은 3단계에서 Redis로 처리 예정. 현재 MySQL status는 영구 기록용
- **@ManyToOne LAZY**: N+1 방지. Game→GameSeat은 양방향 안 걸음 (좌석 2만 건 메모리 로딩 방지)
- **GameSeat 인덱스**: game_id 인덱스 추가 (좌석 배치도 조회 성능 목표 3,000 req/s)

## Test plan
- [ ] `./gradlew build` 빌드 성공 확인
- [ ] Postman으로 구역 등록 → 좌석 등록 → 경기 등록 → 경기 조회 → 좌석 배치도 조회 흐름 테스트
- [ ] 경기 등록 시 GameSeat 자동 생성 확인
- [ ] 존재하지 않는 gameId 조회 시 404 응답 확인
